### PR TITLE
readme update to include binary download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@
 I have the final zip(lambda_function.zip) file to upload in aws lambda and you can the edit the lambda_function.py for your requirements.
 ```
 
+### Binary download links (for reference)
+- [chromedriver](http://chromedriver.chromium.org/downloads), unzip and put in the bin directory (make sure it is named chromedriver)
+- [headless-chromium](https://github.com/adieuadieu/serverless-chrome/releases), unzip and put in the bin directory (make sure it is named headless-chromium)


### PR DESCRIPTION
This is just for reference of where to get these binaries in the future as both chromedriver and chromium are updated to new versions.